### PR TITLE
fix: switch to /org/site path prefix

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -60,7 +60,8 @@ export async function resolveConfig(ctx, tenant, overrides = {}) {
     suffix,
   );
 
-  const [org = '', repo = ''] = tenant.split('--');
+  const [org, repo] = tenant.split('--');
+
   // merge configs
   /** @type {Config} */
   const resolved = {

--- a/src/config.js
+++ b/src/config.js
@@ -60,6 +60,7 @@ export async function resolveConfig(ctx, tenant, overrides = {}) {
     suffix,
   );
 
+  const [owner = '', repo = ''] = tenant.split('--');
   // merge configs
   /** @type {Config} */
   const resolved = {
@@ -79,9 +80,10 @@ export async function resolveConfig(ctx, tenant, overrides = {}) {
       headers: confMap.base?.headers ?? {},
       params: {},
     }),
+    owner,
+    repo,
     ...overrides,
   };
-
   // ensure validity
   // TODO: make this more robust
   if (!resolved.pageType) {

--- a/src/config.js
+++ b/src/config.js
@@ -60,7 +60,7 @@ export async function resolveConfig(ctx, tenant, overrides = {}) {
     suffix,
   );
 
-  const [owner = '', repo = ''] = tenant.split('--');
+  const [org = '', repo = ''] = tenant.split('--');
   // merge configs
   /** @type {Config} */
   const resolved = {
@@ -80,7 +80,7 @@ export async function resolveConfig(ctx, tenant, overrides = {}) {
       headers: confMap.base?.headers ?? {},
       params: {},
     }),
-    owner,
+    org,
     repo,
     ...overrides,
   };

--- a/src/index.js
+++ b/src/index.js
@@ -41,14 +41,14 @@ async function fetchProduct(sku, config) {
   const query = getProductQuery({ sku });
   console.debug(query);
 
-  const resp = await ffetch(`${catalogEndpoint}?query=${encodeURIComponent(query)}&view=${config.magentoStoreViewCode}`, {
+  const resp = await ffetch(`${catalogEndpoint}?query=${encodeURIComponent(query)}&view=${config.storeViewCode}`, {
     headers: {
       origin: config.origin ?? 'https://api.adobecommerce.live',
       'x-api-key': config.apiKey,
       'Magento-Environment-Id': config.magentoEnvironmentId,
       'Magento-Website-Code': config.magentoWebsiteCode,
-      'Magento-Store-View-Code': config.magentoStoreViewCode,
-      'Magento-Store-Code': config.magentoStoreCode,
+      'Magento-Store-View-Code': config.storeViewCode,
+      'Magento-Store-Code': config.storeCode,
       ...config.headers,
     },
     cf: {
@@ -87,14 +87,14 @@ async function fetchVariants(sku, config) {
   const query = getVariantsQuery(sku);
   console.debug(query);
 
-  const resp = await ffetch(`${catalogEndpoint}?query=${encodeURIComponent(query)}&view=${config.magentoStoreViewCode}`, {
+  const resp = await ffetch(`${catalogEndpoint}?query=${encodeURIComponent(query)}&view=${config.storeViewCode}`, {
     headers: {
       origin: config.origin ?? 'https://api.adobecommerce.live',
       'x-api-key': config.apiKey,
       'Magento-Environment-Id': config.magentoEnvironmentId,
       'Magento-Website-Code': config.magentoWebsiteCode,
-      'Magento-Store-View-Code': config.magentoStoreViewCode,
-      'Magento-Store-Code': config.magentoStoreCode,
+      'Magento-Store-View-Code': config.storeViewCode,
+      'Magento-Store-Code': config.storeCode,
       ...config.headers,
     },
     cf: {
@@ -136,8 +136,8 @@ async function lookupProductSKU(urlkey, config) {
       'x-api-key': config.apiKey,
       'Magento-Environment-Id': config.magentoEnvironmentId,
       'Magento-Website-Code': config.magentoWebsiteCode,
-      'Magento-Store-View-Code': config.magentoStoreViewCode,
-      'Magento-Store-Code': config.magentoStoreCode,
+      'Magento-Store-View-Code': config.storeViewCode,
+      'Magento-Store-Code': config.storeCode,
       ...config.headers,
     },
     // don't disable cache, since it's unlikely to change

--- a/src/index.js
+++ b/src/index.js
@@ -225,23 +225,15 @@ export default {
       return errorResponse(405, 'method not allowed');
     }
 
-    const [_, tenant, route] = ctx.url.pathname.split('/');
-    if (!tenant) {
-      return errorResponse(404, 'missing tenant');
-    }
-    if (!route) {
-      return errorResponse(404, 'missing route');
-    }
-
     try {
       const overrides = Object.fromEntries(ctx.url.searchParams.entries());
-      const config = await resolveConfig(ctx, tenant, overrides);
+      const config = await resolveConfig(ctx, overrides);
       console.debug('resolved config: ', JSON.stringify(config));
       if (!config) {
         return errorResponse(404, 'config not found');
       }
 
-      return handlers[route](ctx, config);
+      return handlers[config.route](ctx, config);
     } catch (e) {
       if (e.response) {
         return e.response;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -7,8 +7,8 @@ declare global {
     apiKey: string;
     magentoEnvironmentId: string;
     magentoWebsiteCode: string;
-    magentoStoreViewCode: string;
-    magentoStoreCode: string;
+    storeViewCode: string;
+    storeCode: string;
     coreEndpoint: string;
     catalogEndpoint?: string;
     params: Record<string, string>;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -2,6 +2,9 @@ import type { ExecutionContext, KVNamespace } from "@cloudflare/workers-types/ex
 
 declare global {
   export interface Config {
+    org: string;
+    site: string;
+    route: string;
     pageType: 'product' | string;
     origin?: string;
     apiKey: string;

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -25,7 +25,7 @@ const TEST_CONTEXT = (path, configMap) => ({
     },
   },
   log: console,
-  url: new URL(`https://www.example.com/tenant/content${path}`),
+  url: new URL(`https://www.example.com/owner--repo/content${path}`),
   info: {
     method: 'GET',
     headers: {},
@@ -35,7 +35,7 @@ const TEST_CONTEXT = (path, configMap) => ({
 describe('config tests', () => {
   it('should extract path params', async () => {
     const tenantConfigs = {
-      'test-tenant': {
+      'owner--repo': {
         base: {
           apiKey: 'bad',
         },
@@ -47,19 +47,21 @@ describe('config tests', () => {
     };
     const config = await resolveConfig(
       TEST_CONTEXT('/us/p/my-url-key/some-sku', tenantConfigs),
-      'test-tenant',
+      'owner--repo',
     );
     assert.deepStrictEqual(config, {
       apiKey: 'good',
       params: { urlkey: 'my-url-key', sku: 'some-sku' },
       headers: {},
       pageType: 'product',
+      owner: 'owner',
+      repo: 'repo',
     });
   });
 
   it('should combine headers objects', async () => {
     const tenantConfigs = {
-      'test-tenant': {
+      'owner--repo': {
         base: {
           apiKey: 'bad',
           headers: {
@@ -79,19 +81,21 @@ describe('config tests', () => {
     };
     const config = await resolveConfig(
       TEST_CONTEXT('/us/p/my-url-key/some-sku', tenantConfigs),
-      'test-tenant',
+      'owner--repo',
     );
     assert.deepStrictEqual(config, {
       apiKey: 'good',
       params: { urlkey: 'my-url-key', sku: 'some-sku' },
       headers: { foo: '2', baz: '1', bar: '2' },
       pageType: 'product',
+      owner: 'owner',
+      repo: 'repo',
     });
   });
 
   it('should allow wildcard path segments', async () => {
     const tenantConfigs = {
-      'test-tenant': {
+      'owner--repo': {
         base: {
           apiKey: 'bad',
         },
@@ -103,19 +107,21 @@ describe('config tests', () => {
     };
     const config = await resolveConfig(
       TEST_CONTEXT('/us/p/something-here/some-sku', tenantConfigs),
-      'test-tenant',
+      'owner--repo',
     );
     assert.deepStrictEqual(config, {
       apiKey: 'good',
       params: { sku: 'some-sku' },
       headers: {},
       pageType: 'product',
+      owner: 'owner',
+      repo: 'repo',
     });
   });
 
   it('should allow overrides', async () => {
     const tenantConfigs = {
-      'test-tenant': {
+      'owner--repo': {
         base: {
           apiKey: 'bad1',
         },
@@ -127,7 +133,7 @@ describe('config tests', () => {
     };
     const config = await resolveConfig(
       TEST_CONTEXT('/us/p/some-sku', tenantConfigs),
-      'test-tenant',
+      'owner--repo',
       { apiKey: 'good' },
     );
     assert.deepStrictEqual(config, {
@@ -135,6 +141,8 @@ describe('config tests', () => {
       params: { sku: 'some-sku' },
       pageType: 'product',
       headers: {},
+      owner: 'owner',
+      repo: 'repo',
     });
   });
 });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -25,7 +25,7 @@ const TEST_CONTEXT = (path, configMap) => ({
     },
   },
   log: console,
-  url: new URL(`https://www.example.com/owner--repo/content${path}`),
+  url: new URL(`https://www.example.com/org--repo/content${path}`),
   info: {
     method: 'GET',
     headers: {},
@@ -35,7 +35,7 @@ const TEST_CONTEXT = (path, configMap) => ({
 describe('config tests', () => {
   it('should extract path params', async () => {
     const tenantConfigs = {
-      'owner--repo': {
+      'org--repo': {
         base: {
           apiKey: 'bad',
         },
@@ -47,21 +47,21 @@ describe('config tests', () => {
     };
     const config = await resolveConfig(
       TEST_CONTEXT('/us/p/my-url-key/some-sku', tenantConfigs),
-      'owner--repo',
+      'org--repo',
     );
     assert.deepStrictEqual(config, {
       apiKey: 'good',
       params: { urlkey: 'my-url-key', sku: 'some-sku' },
       headers: {},
       pageType: 'product',
-      owner: 'owner',
+      org: 'org',
       repo: 'repo',
     });
   });
 
   it('should combine headers objects', async () => {
     const tenantConfigs = {
-      'owner--repo': {
+      'org--repo': {
         base: {
           apiKey: 'bad',
           headers: {
@@ -81,21 +81,21 @@ describe('config tests', () => {
     };
     const config = await resolveConfig(
       TEST_CONTEXT('/us/p/my-url-key/some-sku', tenantConfigs),
-      'owner--repo',
+      'org--repo',
     );
     assert.deepStrictEqual(config, {
       apiKey: 'good',
       params: { urlkey: 'my-url-key', sku: 'some-sku' },
       headers: { foo: '2', baz: '1', bar: '2' },
       pageType: 'product',
-      owner: 'owner',
+      org: 'org',
       repo: 'repo',
     });
   });
 
   it('should allow wildcard path segments', async () => {
     const tenantConfigs = {
-      'owner--repo': {
+      'org--repo': {
         base: {
           apiKey: 'bad',
         },
@@ -107,21 +107,21 @@ describe('config tests', () => {
     };
     const config = await resolveConfig(
       TEST_CONTEXT('/us/p/something-here/some-sku', tenantConfigs),
-      'owner--repo',
+      'org--repo',
     );
     assert.deepStrictEqual(config, {
       apiKey: 'good',
       params: { sku: 'some-sku' },
       headers: {},
       pageType: 'product',
-      owner: 'owner',
+      org: 'org',
       repo: 'repo',
     });
   });
 
   it('should allow overrides', async () => {
     const tenantConfigs = {
-      'owner--repo': {
+      'org--repo': {
         base: {
           apiKey: 'bad1',
         },
@@ -133,7 +133,7 @@ describe('config tests', () => {
     };
     const config = await resolveConfig(
       TEST_CONTEXT('/us/p/some-sku', tenantConfigs),
-      'owner--repo',
+      'org--repo',
       { apiKey: 'good' },
     );
     assert.deepStrictEqual(config, {
@@ -141,7 +141,7 @@ describe('config tests', () => {
       params: { sku: 'some-sku' },
       pageType: 'product',
       headers: {},
-      owner: 'owner',
+      org: 'org',
       repo: 'repo',
     });
   });


### PR DESCRIPTION
- Change path prefix to `/org/site` format.
- Drop `magento` from `magentoStoreCode` and `magentoStoreViewCode` (Breaking change)

Keeping `magentoWebsiteCode` since that will be a configuration parameter that is specific to sites running on Magento. `repo` will be the equivalent for sites using catalog storage.

The kv should be updated to just after merging to drop `magento` from `magentoStoreCode` and `magentoStoreViewCode`.