### PR TITLE
fix: don't assume uppercase skus

### DIFF
--- a/src/content/adobe-commerce.js
+++ b/src/content/adobe-commerce.js
@@ -171,7 +171,7 @@ export async function handle(ctx) {
 
   // If urlkey is provided, lookup sku by urlkey from core to ensure we have the right casing
   // Sku is case-sensitive in Adobe Commerce
-  // TODO: Need a way to handle paths with only sku (where sku is uppercase...)
+  // TODO: Need a way to handle paths with only sku (where sku should be uppercase...)
   if (urlkey) {
     // lookup sku by urlkey with core
     // TODO: test if livesearch if enabled

--- a/src/content/adobe-commerce.js
+++ b/src/content/adobe-commerce.js
@@ -169,7 +169,10 @@ export async function handle(ctx) {
     return errorResponse(400, 'missing sku and coreEndpoint');
   }
 
-  if (!sku) {
+  // If urlkey is provided, lookup sku by urlkey from core to ensure we have the right casing
+  // Sku is case-sensitive in Adobe Commerce
+  // TODO: Need a way to handle paths with only sku (where sku is uppercase...)
+  if (urlkey) {
     // lookup sku by urlkey with core
     // TODO: test if livesearch if enabled
     sku = await lookupProductSKU(urlkey, config);
@@ -177,8 +180,8 @@ export async function handle(ctx) {
 
   // const product = await fetchProductCore({ sku }, config);
   const [product, variants] = await Promise.all([
-    fetchProduct(sku.toUpperCase(), config),
-    fetchVariants(sku.toUpperCase(), config),
+    fetchProduct(sku, config),
+    fetchVariants(sku, config),
   ]);
   const html = htmlTemplateFromContext(ctx, product, variants).render();
   return new Response(html, {


### PR DESCRIPTION
SKU's can be `my-product-sku` so we can't force it to be uppercase and should instead try and get the correct casing from core.