### PR TITLE
feat: product:lastModifiedAt from Catalog Service

### DIFF
--- a/src/content/queries/cs-product.js
+++ b/src/content/queries/cs-product.js
@@ -37,6 +37,7 @@ export const adapter = (config, productData) => {
   const product = {
     sku: productData.sku,
     name: productData.name,
+    lastModifiedAt: productData.lastModifiedAt,
     metaTitle: productData.metaTitle,
     metaDescription: productData.metaDescription,
     metaKeyword: productData.metaKeyword,
@@ -153,6 +154,7 @@ export default ({ sku, imageRoles = [], linkTypes = [] }) => gql`{
     ) {
       id
       sku
+      lastModifiedAt
       name
       metaTitle
       metaDescription

--- a/src/templates/html/HTMLTemplate.js
+++ b/src/templates/html/HTMLTemplate.js
@@ -131,7 +131,8 @@ ${HTMLTemplate.metaName('addToCartAllowed', product.addToCartAllowed)}
 ${HTMLTemplate.metaName('inStock', product.inStock ? 'true' : 'false')}
 ${HTMLTemplate.metaProperty('product:availability', product.inStock ? 'In stock' : 'Out of stock')}
 ${HTMLTemplate.metaProperty('product:price.amount', product.prices?.final?.amount)}
-${HTMLTemplate.metaProperty('product:price.currency', product.prices?.final?.currency)}`;
+${HTMLTemplate.metaProperty('product:price.currency', product.prices?.final?.currency)}
+${HTMLTemplate.metaProperty('product:lastModifiedAt', product.lastModifiedAt)}`;
   }
 
   /**

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -199,6 +199,9 @@ declare global {
     rating?: Rating;
     links?: Link[];
 
+    // Coming only from Catalog Service at the time of writing:
+    lastModifiedAt?: string;
+
     // not handled currently:
     externalParentId?: string;
     variantSku?: string;

--- a/test/fixtures/post-deploy/bella-tank.html
+++ b/test/fixtures/post-deploy/bella-tank.html
@@ -22,7 +22,6 @@
   <meta name="externalId" content="5068">
   <meta name="addToCartAllowed" content="true">
   <meta name="inStock" content="true">
-  <meta name="lastModifiedAtCS" content="2024-12-16T06:25:43.024Z">
   <meta property="product:availability" content="In stock">
   <meta property="product:price.amount" content="29">
   <meta property="product:price.currency" content="USD">

--- a/test/fixtures/post-deploy/bella-tank.html
+++ b/test/fixtures/post-deploy/bella-tank.html
@@ -25,6 +25,7 @@
   <meta property="product:availability" content="In stock">
   <meta property="product:price.amount" content="29">
   <meta property="product:price.currency" content="USD">
+  <meta property="product:lastModifiedAt" content="2024-12-16T06:25:43.024Z">
   <script src="/scripts/aem.js" type="module"></script>
   <script src="/scripts/scripts.js" type="module"></script>
   <link rel="stylesheet" href="/styles/styles.css">

--- a/test/fixtures/post-deploy/bella-tank.html
+++ b/test/fixtures/post-deploy/bella-tank.html
@@ -25,7 +25,6 @@
   <meta property="product:availability" content="In stock">
   <meta property="product:price.amount" content="29">
   <meta property="product:price.currency" content="USD">
-  <meta property="product:lastModifiedAt" content="2024-12-16T06:25:43.024Z">
   <script src="/scripts/aem.js" type="module"></script>
   <script src="/scripts/scripts.js" type="module"></script>
   <link rel="stylesheet" href="/styles/styles.css">

--- a/test/post-deploy.test.js
+++ b/test/post-deploy.test.js
@@ -65,8 +65,14 @@ describe('Post-Deploy Tests', () => {
     const expected = await getHTMLFixture('bella-tank');
 
     assert.strictEqual(res.status, 200);
-    const actual = await res.text();
+    let actual = await res.text();
     const differ = new HtmlDiffer();
+
+    const regex = /<meta\s+property="product:lastModifiedAt"\s+content="[^"]*"\s*>/;
+    const match = actual.match(regex);
+    assert(match, 'product:lastModifiedAt should be present');
+
+    actual = actual.replace(regex, '');
 
     // @ts-ignore
     assert.ok(differ.isEqual(actual, expected));

--- a/test/post-deploy.test.js
+++ b/test/post-deploy.test.js
@@ -68,9 +68,9 @@ describe('Post-Deploy Tests', () => {
     let actual = await res.text();
     const differ = new HtmlDiffer();
 
-    const regex = /<meta\s+property="product:lastModifiedAt"\s+content="[^"]*"\s*>/;
+    const regex = /<meta\s+name="lastModifiedAtCS"\s+content="[^"]*"\s*>/;
     const match = actual.match(regex);
-    assert(match, 'product:lastModifiedAt should be present');
+    assert(match, 'lastModifiedAtCS should be present');
 
     actual = actual.replace(regex, '');
 

--- a/test/templates/html/index.test.js
+++ b/test/templates/html/index.test.js
@@ -466,4 +466,16 @@ describe('Render Product HTML', () => {
     const ogImage = document.querySelector('meta[name="image"]');
     assert.strictEqual(ogImage.getAttribute('content'), '/media/catalog/product/t/s/test-sku.png');
   });
+
+  it('should allow for undefined lastModifiedAt', () => {
+    product.lastModifiedAt = undefined;
+
+    const html = htmlTemplateFromContext(DEFAULT_CONTEXT({ config }), product, variations).render();
+
+    dom = new JSDOM(html);
+    document = dom.window.document;
+
+    const metaProductLastModified = document.querySelector('meta[property="product:lastModifiedAt"]');
+    assert.strictEqual(metaProductLastModified.getAttribute('content'), 'undefined', 'meta[property="product:lastModifiedAt"] should be undefined');
+  });
 });

--- a/test/templates/html/index.test.js
+++ b/test/templates/html/index.test.js
@@ -475,7 +475,7 @@ describe('Render Product HTML', () => {
     dom = new JSDOM(html);
     document = dom.window.document;
 
-    const metaProductLastModified = document.querySelector('meta[property="product:lastModifiedAt"]');
-    assert.strictEqual(metaProductLastModified.getAttribute('content'), 'undefined', 'meta[property="product:lastModifiedAt"] should be undefined');
+    const metaProductLastModified = document.querySelector('meta[name="lastModifiedAtCS"]');
+    assert.strictEqual(metaProductLastModified.getAttribute('content'), 'undefined', 'meta[name="lastModifiedAtCS"] should be undefined');
   });
 });

--- a/test/templates/html/index.test.js
+++ b/test/templates/html/index.test.js
@@ -467,7 +467,7 @@ describe('Render Product HTML', () => {
     assert.strictEqual(ogImage.getAttribute('content'), '/media/catalog/product/t/s/test-sku.png');
   });
 
-  it('should allow for undefined lastModifiedAt', () => {
+  it('lastModifiedAtCS is not present if lastModifiedAt is undefined', () => {
     product.lastModifiedAt = undefined;
 
     const html = htmlTemplateFromContext(DEFAULT_CONTEXT({ config }), product, variations).render();
@@ -476,6 +476,6 @@ describe('Render Product HTML', () => {
     document = dom.window.document;
 
     const metaProductLastModified = document.querySelector('meta[name="lastModifiedAtCS"]');
-    assert.strictEqual(metaProductLastModified.getAttribute('content'), 'undefined', 'meta[name="lastModifiedAtCS"] should be undefined');
+    assert(!metaProductLastModified, 'meta[name="lastModifiedAtCS"] should not be in the document');
   });
 });


### PR DESCRIPTION
PR proposed for #67 
According to the proposed implementation, this `product:lastModifiedAt` is rendered as a meta tag by default, and can have `undefined` value in case the data source does not expose it.